### PR TITLE
Unnecessary/buggy call to sql_free_result

### DIFF
--- a/Classes/PreProcessor/Tx_FormhandlerSubscription_PreProcessor_ValidateAuthCodeDB.php
+++ b/Classes/PreProcessor/Tx_FormhandlerSubscription_PreProcessor_ValidateAuthCodeDB.php
@@ -162,8 +162,6 @@ class Tx_FormhandlerSubscription_PreProcessor_ValidateAuthCodeDB extends Tx_Form
 		if (!$res) {
 			$this->utilityFuncs->throwException('validateauthcode_update_failed');
 		}
-
-		$GLOBALS['TYPO3_DB']->sql_free_result($res);
 	}
 }
 ?>


### PR DESCRIPTION
This call to `$GLOBALS['TYPO3_DB']->sql_free_result($res);` throw php warning because `$res` is a boolean, not a valid sql resource.
In my development configuration, I turn all php warnings into exception, and this cause the user to be redirect to the _Invalid authcode_ page.

```
$res = $GLOBALS['TYPO3_DB']->exec_UPDATEquery($updateTable, $uidField . '=' . $uid, array($hiddenField => 0));
if (!$res) {
    $this->utilityFuncs->throwException('validateauthcode_update_failed');
}

$GLOBALS['TYPO3_DB']->sql_free_result($res);
```

Plus, according to the php documentation (http://php.net/manual/en/function.mysql-free-result.php), there is no need to do a mysql_free_result after an UPDATE request.
